### PR TITLE
Problem: COSS editors are implied to be gatekeepers

### DIFF
--- a/2/README.md
+++ b/2/README.md
@@ -99,7 +99,12 @@ When deprecated specifications are no longer used in products, they become **ret
 ## Editorial control
 
 
-A specification has a single responsible editor, who is the only person that can edit the text and change its status.  A specification may also have additional contributors who work through the editor.  The editor is responsible for accurately maintaining the state of specifications and for handling all comments on the specification.
+A specification MUST have a single responsible editor, the only person
+who SHALL change the status of the specification through the lifecycle stages.
+
+A specification MAY also have additional contributors who contribute changes to it. It is RECOMMENDED to use the [C4 process](../1/README.md) to maximize the scale and diversity of contributions.
+
+The editor is responsible for accurately maintaining the state of specifications and for handling all comments on the specification.
 
 ## Branching and Merging
 


### PR DESCRIPTION
Solution: remove the language that suggests gatekeeping
and recommend the use of the C4 process.
